### PR TITLE
5weeks deafult

### DIFF
--- a/src/main/java/study/shinseungyeol/backend/api/ControllerAdvice.java
+++ b/src/main/java/study/shinseungyeol/backend/api/ControllerAdvice.java
@@ -6,9 +6,19 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import study.shinseungyeol.backend.exception.CustomException;
+import study.shinseungyeol.backend.exception.ErrorCode;
 
 @RestControllerAdvice
 public class ControllerAdvice extends ResponseEntityExceptionHandler {
+
+  @ExceptionHandler(value = {CustomException.class})
+  public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+    ErrorCode errorCode = e.getErrorCode();
+
+    return ResponseEntity.status(errorCode.getStatus())
+        .body(new ErrorResponse(errorCode.getCode(), errorCode.getMessage()));
+  }
 
   @ExceptionHandler(value = {NoSuchElementException.class})
   public ResponseEntity<ErrorResponse> handleNotFoundException(NoSuchElementException ex) {

--- a/src/main/java/study/shinseungyeol/backend/domain/concert/ConcertService.java
+++ b/src/main/java/study/shinseungyeol/backend/domain/concert/ConcertService.java
@@ -2,9 +2,10 @@ package study.shinseungyeol.backend.domain.concert;
 
 import jakarta.transaction.Transactional;
 import java.util.List;
-import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import study.shinseungyeol.backend.exception.CustomException;
+import study.shinseungyeol.backend.exception.ErrorCode;
 
 @Service
 @RequiredArgsConstructor
@@ -22,7 +23,7 @@ public class ConcertService {
    */
   public List<ConcertSeat> getAvailableConcertSeats(Long concertId) {
     Concert concert = concertRepository.findById(concertId)
-        .orElseThrow(() -> new NoSuchElementException());
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CONCERT));
 
     return concertSeatRepository.findAllAvailableSeats(concert);
   }
@@ -35,7 +36,7 @@ public class ConcertService {
    */
   public List<ConcertSchedule> getAvailableConcertSchedules(Long concertId) {
     Concert concert = concertRepository.findById(concertId)
-        .orElseThrow(() -> new NoSuchElementException());
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CONCERT));
 
     return concertScheduleRepository.findAllByConcert(
             concert).stream()
@@ -53,7 +54,7 @@ public class ConcertService {
    */
   public void checkAvailableConcertSeatWithLock(Long concertSeatId) {
     ConcertSeat concertSeat = concertSeatRepository.findByIdForUpdate(concertSeatId)
-        .orElseThrow(() -> new NoSuchElementException());
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_SEAT));
 
     if (!concertSeat.getAvailable()) {
       throw new IllegalStateException("not available");
@@ -68,7 +69,7 @@ public class ConcertService {
    */
   public ConcertSeat getConcertSeat(Long concertSeatId) {
     return concertSeatRepository.findByIdForUpdate(concertSeatId)
-        .orElseThrow(() -> new NoSuchElementException());
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_SEAT));
   }
 
   /**
@@ -78,7 +79,7 @@ public class ConcertService {
    */
   public void convertConcertSeatToOccupied(Long concertSeatId) {
     ConcertSeat concertSeat = concertSeatRepository.findByIdForUpdate(concertSeatId)
-        .orElseThrow(() -> new NoSuchElementException());
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_SEAT));
 
     concertSeat.occupied();
   }
@@ -90,7 +91,7 @@ public class ConcertService {
    */
   public void convertConcertSeatToAvailable(Long concertSeatId) {
     ConcertSeat concertSeat = concertSeatRepository.findByIdForUpdate(concertSeatId)
-        .orElseThrow(() -> new NoSuchElementException());
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_SEAT));
 
     concertSeat.available();
   }

--- a/src/main/java/study/shinseungyeol/backend/domain/point/Point.java
+++ b/src/main/java/study/shinseungyeol/backend/domain/point/Point.java
@@ -12,6 +12,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import study.shinseungyeol.backend.domain.BaseEntity;
+import study.shinseungyeol.backend.exception.CustomException;
+import study.shinseungyeol.backend.exception.ErrorCode;
 
 @Entity
 @Getter
@@ -71,8 +73,7 @@ public class Point extends BaseEntity {
     }
 
     if (balanceAmount.compareTo(amount) < 0) {
-      throw new IllegalStateException(
-          "Insufficient balance. The balance amount must be greater than or equal to the required amount.");
+      throw new CustomException(ErrorCode.NOT_ENOUGH_BALANCE);
     }
 
     BigDecimal subtracted = balanceAmount.subtract(amount);

--- a/src/main/java/study/shinseungyeol/backend/domain/point/PointService.java
+++ b/src/main/java/study/shinseungyeol/backend/domain/point/PointService.java
@@ -2,9 +2,10 @@ package study.shinseungyeol.backend.domain.point;
 
 import jakarta.transaction.Transactional;
 import java.math.BigDecimal;
-import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import study.shinseungyeol.backend.exception.CustomException;
+import study.shinseungyeol.backend.exception.ErrorCode;
 
 @Service
 @RequiredArgsConstructor
@@ -22,7 +23,7 @@ public class PointService {
    */
   public Point usePoint(Long memberId, BigDecimal amount) {
     Point point = pointRepository.findByMemberIdForUpdate(memberId)
-        .orElseThrow(NoSuchElementException::new);
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_MEMBER));
 
     point.usePoint(amount);
 
@@ -40,7 +41,7 @@ public class PointService {
    */
   public Point chargePoint(Long memberId, BigDecimal amount) {
     Point point = pointRepository.findByMemberIdForUpdate(memberId)
-        .orElseThrow(NoSuchElementException::new);
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_MEMBER));
 
     point.addPoint(amount);
 
@@ -58,6 +59,6 @@ public class PointService {
    */
   public Point getPointByMemberId(Long memberId) {
     return pointRepository.findByMemberId(memberId)
-        .orElseThrow(NoSuchElementException::new);
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_MEMBER));
   }
 }

--- a/src/main/java/study/shinseungyeol/backend/domain/point/PointService.java
+++ b/src/main/java/study/shinseungyeol/backend/domain/point/PointService.java
@@ -23,7 +23,7 @@ public class PointService {
    */
   public Point usePoint(Long memberId, BigDecimal amount) {
     Point point = pointRepository.findByMemberIdForUpdate(memberId)
-        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_MEMBER));
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_POINT));
 
     point.usePoint(amount);
 
@@ -41,7 +41,7 @@ public class PointService {
    */
   public Point chargePoint(Long memberId, BigDecimal amount) {
     Point point = pointRepository.findByMemberIdForUpdate(memberId)
-        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_MEMBER));
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_POINT));
 
     point.addPoint(amount);
 
@@ -59,6 +59,6 @@ public class PointService {
    */
   public Point getPointByMemberId(Long memberId) {
     return pointRepository.findByMemberId(memberId)
-        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_MEMBER));
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_POINT));
   }
 }

--- a/src/main/java/study/shinseungyeol/backend/domain/reservation/ConcertSeatReservation.java
+++ b/src/main/java/study/shinseungyeol/backend/domain/reservation/ConcertSeatReservation.java
@@ -17,6 +17,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import study.shinseungyeol.backend.domain.BaseEntity;
+import study.shinseungyeol.backend.exception.CustomException;
+import study.shinseungyeol.backend.exception.ErrorCode;
 
 @Entity
 @Getter
@@ -85,7 +87,10 @@ public class ConcertSeatReservation extends BaseEntity {
   /**
    * 예약 만료되었는지 리턴
    */
-  public boolean isExpired() {
-    return LocalDateTime.now().isAfter(expireAt);
+  public void checkIsExpired() {
+
+    if (LocalDateTime.now().isAfter(expireAt)) {
+      throw new CustomException(ErrorCode.EXPIRED_SEAT_RESERVATION);
+    }
   }
 }

--- a/src/main/java/study/shinseungyeol/backend/domain/reservation/ConcertSeatReservationService.java
+++ b/src/main/java/study/shinseungyeol/backend/domain/reservation/ConcertSeatReservationService.java
@@ -3,9 +3,10 @@ package study.shinseungyeol.backend.domain.reservation;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import study.shinseungyeol.backend.exception.CustomException;
+import study.shinseungyeol.backend.exception.ErrorCode;
 
 @Service
 @RequiredArgsConstructor
@@ -54,11 +55,9 @@ public class ConcertSeatReservationService {
   public ConcertSeatReservation completeConcertSeatReservation(Long concertSeatReservationId) {
     ConcertSeatReservation concertSeatReservation = reservationRepository.findByIdForUpdate(
             concertSeatReservationId)
-        .orElseThrow(() -> new NoSuchElementException());
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_RESERVATION));
 
-    if (concertSeatReservation.isExpired()) {
-      throw new IllegalStateException("expired");
-    }
+    concertSeatReservation.checkIsExpired();
 
     concertSeatReservation.complete();
 

--- a/src/main/java/study/shinseungyeol/backend/domain/token/TokenService.java
+++ b/src/main/java/study/shinseungyeol/backend/domain/token/TokenService.java
@@ -1,13 +1,14 @@
 package study.shinseungyeol.backend.domain.token;
 
 import jakarta.transaction.Transactional;
-import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import study.shinseungyeol.backend.exception.CustomException;
+import study.shinseungyeol.backend.exception.ErrorCode;
 
 @Service
 @RequiredArgsConstructor
@@ -60,7 +61,7 @@ public class TokenService {
    */
   public Token getTokenWithValidateActive(UUID uuid) {
     Token token = tokenRepository.findByIdForUpdate(uuid)
-        .orElseThrow(() -> new NoSuchElementException());
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_TOKEN));
     token.validateActive();
 
     return token;
@@ -73,7 +74,8 @@ public class TokenService {
    * @return
    */
   public Token getToken(UUID uuid) {
-    return tokenRepository.findByIdForUpdate(uuid).orElseThrow(() -> new NoSuchElementException());
+    return tokenRepository.findByIdForUpdate(uuid)
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_TOKEN));
 
   }
 

--- a/src/main/java/study/shinseungyeol/backend/exception/CustomException.java
+++ b/src/main/java/study/shinseungyeol/backend/exception/CustomException.java
@@ -1,0 +1,12 @@
+package study.shinseungyeol.backend.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CustomException extends RuntimeException {
+
+  private ErrorCode errorCode;
+
+}

--- a/src/main/java/study/shinseungyeol/backend/exception/ErrorCode.java
+++ b/src/main/java/study/shinseungyeol/backend/exception/ErrorCode.java
@@ -1,0 +1,25 @@
+package study.shinseungyeol.backend.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+  NOT_FOUND_USER(HttpStatus.NOT_FOUND, "NFU001", "사용자를 찾을 수 없습니다."),
+  NOT_FOUND_CONCERT(HttpStatus.NOT_FOUND, "NFC002", "콘서트를 찾을 수 없습니다."),
+  NOT_FOUND_SEAT(HttpStatus.NOT_FOUND, "NFS003", "콘서트 좌석을 찾을 수 없습니다."),
+  NOT_FOUND_TOKEN(HttpStatus.NOT_FOUND, "NFT004", "토큰을 찾을 수 없습니다."),
+  NOT_FOUND_POINT(HttpStatus.NOT_FOUND, "NFP005", "포인트를 찾을 수 없습니다."),
+
+  NOT_AVAILABLE_SEAT(HttpStatus.BAD_REQUEST, "NAS006", "좌석이 사용 가능 상태가 아닙니다"),
+  NOT_ENOUGH_POINT(HttpStatus.PAYMENT_REQUIRED, "EEP007", "포인트가 부족합니다."),
+  EXPIRED_SEAT_RESERVATION(HttpStatus.BAD_REQUEST, "ESR008", "좌석 예약이 이미 만료되었습니다"),
+  NOT_ACTIVE_TOKEN(HttpStatus.FORBIDDEN, "NAT009", "토큰이 액티브 상태가 아닙니다"),
+  ;
+
+  private HttpStatus status;
+  private String code;
+  private String message;
+}

--- a/src/main/java/study/shinseungyeol/backend/exception/ErrorCode.java
+++ b/src/main/java/study/shinseungyeol/backend/exception/ErrorCode.java
@@ -12,11 +12,12 @@ public enum ErrorCode {
   NOT_FOUND_SEAT(HttpStatus.NOT_FOUND, "NFS003", "콘서트 좌석을 찾을 수 없습니다."),
   NOT_FOUND_TOKEN(HttpStatus.NOT_FOUND, "NFT004", "토큰을 찾을 수 없습니다."),
   NOT_FOUND_POINT(HttpStatus.NOT_FOUND, "NFP005", "포인트를 찾을 수 없습니다."),
+  NOT_FOUND_RESERVATION(HttpStatus.NOT_FOUND, "NFR006", "예약 내역을 찾을 수 없습니다"),
 
-  NOT_AVAILABLE_SEAT(HttpStatus.BAD_REQUEST, "NAS006", "좌석이 사용 가능 상태가 아닙니다"),
-  NOT_ENOUGH_BALANCE(HttpStatus.PAYMENT_REQUIRED, "EEP007", "포인트가 부족합니다."),
-  EXPIRED_SEAT_RESERVATION(HttpStatus.BAD_REQUEST, "ESR008", "좌석 예약이 이미 만료되었습니다"),
-  NOT_ACTIVE_TOKEN(HttpStatus.FORBIDDEN, "NAT009", "토큰이 액티브 상태가 아닙니다"),
+  NOT_AVAILABLE_SEAT(HttpStatus.BAD_REQUEST, "NAS007", "좌석이 사용 가능 상태가 아닙니다"),
+  NOT_ENOUGH_BALANCE(HttpStatus.PAYMENT_REQUIRED, "EEP008", "포인트가 부족합니다."),
+  EXPIRED_SEAT_RESERVATION(HttpStatus.BAD_REQUEST, "ESR009", "좌석 예약이 이미 만료되었습니다"),
+  NOT_ACTIVE_TOKEN(HttpStatus.FORBIDDEN, "NAT010", "토큰이 액티브 상태가 아닙니다"),
   ;
 
   private HttpStatus status;

--- a/src/main/java/study/shinseungyeol/backend/exception/ErrorCode.java
+++ b/src/main/java/study/shinseungyeol/backend/exception/ErrorCode.java
@@ -7,14 +7,14 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
-  NOT_FOUND_USER(HttpStatus.NOT_FOUND, "NFU001", "사용자를 찾을 수 없습니다."),
+  NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "NFU001", "사용자를 찾을 수 없습니다."),
   NOT_FOUND_CONCERT(HttpStatus.NOT_FOUND, "NFC002", "콘서트를 찾을 수 없습니다."),
   NOT_FOUND_SEAT(HttpStatus.NOT_FOUND, "NFS003", "콘서트 좌석을 찾을 수 없습니다."),
   NOT_FOUND_TOKEN(HttpStatus.NOT_FOUND, "NFT004", "토큰을 찾을 수 없습니다."),
   NOT_FOUND_POINT(HttpStatus.NOT_FOUND, "NFP005", "포인트를 찾을 수 없습니다."),
 
   NOT_AVAILABLE_SEAT(HttpStatus.BAD_REQUEST, "NAS006", "좌석이 사용 가능 상태가 아닙니다"),
-  NOT_ENOUGH_POINT(HttpStatus.PAYMENT_REQUIRED, "EEP007", "포인트가 부족합니다."),
+  NOT_ENOUGH_BALANCE(HttpStatus.PAYMENT_REQUIRED, "EEP007", "포인트가 부족합니다."),
   EXPIRED_SEAT_RESERVATION(HttpStatus.BAD_REQUEST, "ESR008", "좌석 예약이 이미 만료되었습니다"),
   NOT_ACTIVE_TOKEN(HttpStatus.FORBIDDEN, "NAT009", "토큰이 액티브 상태가 아닙니다"),
   ;

--- a/src/test/java/study/shinseungyeol/backend/domain/concert/ConcertServiceTest.java
+++ b/src/test/java/study/shinseungyeol/backend/domain/concert/ConcertServiceTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -13,6 +12,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import study.shinseungyeol.backend.exception.CustomException;
+import study.shinseungyeol.backend.exception.ErrorCode;
 
 @ExtendWith(MockitoExtension.class)
 class ConcertServiceTest {
@@ -33,27 +34,33 @@ class ConcertServiceTest {
   public void 콘서트_예약_가능_좌석_목록_조회_콘서트_없는_경우() {
     when(concertRepository.findById(1L)).thenReturn(Optional.empty());
 
-    Assertions.assertThrows(NoSuchElementException.class, () -> {
+    CustomException customException = Assertions.assertThrows(CustomException.class, () -> {
       concertService.getAvailableConcertSeats(1L);
     });
+
+    Assertions.assertEquals(ErrorCode.NOT_FOUND_CONCERT, customException.getErrorCode());
   }
 
   @Test
   public void 콘서트_예약_가능_일자_조회_콘서트_없는_경우() {
     when(concertRepository.findById(1L)).thenReturn(Optional.empty());
 
-    Assertions.assertThrows(NoSuchElementException.class, () -> {
+    CustomException customException = Assertions.assertThrows(CustomException.class, () -> {
       concertService.getAvailableConcertSchedules(1L);
     });
+
+    Assertions.assertEquals(ErrorCode.NOT_FOUND_CONCERT, customException.getErrorCode());
   }
 
   @Test
   public void 예약_가능한_좌석_조회_콘서트_좌석이_존재하지_않는_경우() {
     when(concertSeatRepository.findByIdForUpdate(1L)).thenReturn(Optional.empty());
 
-    Assertions.assertThrows(NoSuchElementException.class, () -> {
+    CustomException customException = Assertions.assertThrows(CustomException.class, () -> {
       concertService.checkAvailableConcertSeatWithLock(1L);
     });
+
+    Assertions.assertEquals(ErrorCode.NOT_FOUND_SEAT, customException.getErrorCode());
   }
 
   @Test
@@ -71,21 +78,14 @@ class ConcertServiceTest {
   }
 
   @Test
-  public void 콘서트_특정_ID_조회시_없는_경우_익셉션() {
-    when(concertSeatRepository.findByIdForUpdate(any(Long.class))).thenReturn(Optional.empty());
-
-    Assertions.assertThrows(NoSuchElementException.class, () -> {
-      concertService.getConcertSeat(1L);
-    });
-  }
-
-  @Test
   public void 콘서트_좌석_점유_ID_없는_경우_익셉션() {
     when(concertSeatRepository.findByIdForUpdate(any(Long.class))).thenReturn(Optional.empty());
 
-    Assertions.assertThrows(NoSuchElementException.class, () -> {
+    CustomException customException = Assertions.assertThrows(CustomException.class, () -> {
       concertService.getConcertSeat(1L);
     });
+
+    Assertions.assertEquals(ErrorCode.NOT_FOUND_SEAT, customException.getErrorCode());
   }
 
   @Test
@@ -103,9 +103,11 @@ class ConcertServiceTest {
   public void 콘서트_좌석_사용_가능_상태로_변경_ID_없는_경우_익셉션() {
     when(concertSeatRepository.findByIdForUpdate(any(Long.class))).thenReturn(Optional.empty());
 
-    Assertions.assertThrows(NoSuchElementException.class, () -> {
+    CustomException customException = Assertions.assertThrows(CustomException.class, () -> {
       concertService.convertConcertSeatToAvailable(1L);
     });
+
+    Assertions.assertEquals(ErrorCode.NOT_FOUND_SEAT, customException.getErrorCode());
   }
 
   @Test

--- a/src/test/java/study/shinseungyeol/backend/domain/point/PointServiceTest.java
+++ b/src/test/java/study/shinseungyeol/backend/domain/point/PointServiceTest.java
@@ -62,7 +62,7 @@ class PointServiceTest {
     CustomException customException = assertThrows(CustomException.class,
         () -> pointService.usePoint(1L, BigDecimal.valueOf(100)));
 
-    Assertions.assertEquals(ErrorCode.NOT_FOUND_MEMBER, customException.getErrorCode());
+    Assertions.assertEquals(ErrorCode.NOT_FOUND_POINT, customException.getErrorCode());
   }
 
   @Test
@@ -116,7 +116,7 @@ class PointServiceTest {
     CustomException customException = assertThrows(CustomException.class,
         () -> pointService.chargePoint(1L, BigDecimal.valueOf(100)));
 
-    Assertions.assertEquals(ErrorCode.NOT_FOUND_MEMBER, customException.getErrorCode());
+    Assertions.assertEquals(ErrorCode.NOT_FOUND_POINT, customException.getErrorCode());
   }
 
   @Test
@@ -138,6 +138,6 @@ class PointServiceTest {
     CustomException customException = assertThrows(CustomException.class,
         () -> pointService.getPointByMemberId(1L));
 
-    Assertions.assertEquals(ErrorCode.NOT_FOUND_MEMBER, customException.getErrorCode());
+    Assertions.assertEquals(ErrorCode.NOT_FOUND_POINT, customException.getErrorCode());
   }
 }

--- a/src/test/java/study/shinseungyeol/backend/domain/point/PointServiceTest.java
+++ b/src/test/java/study/shinseungyeol/backend/domain/point/PointServiceTest.java
@@ -7,8 +7,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
-import java.util.NoSuchElementException;
 import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,6 +16,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import study.shinseungyeol.backend.exception.CustomException;
+import study.shinseungyeol.backend.exception.ErrorCode;
 
 @ExtendWith(MockitoExtension.class)
 class PointServiceTest {
@@ -53,6 +55,17 @@ class PointServiceTest {
   }
 
   @Test
+  @DisplayName("포인트 사용시, 멤버 없는 경우 NOT_FOUND_MEMBER Exception")
+  public void 포인트_사용_멤버_없는_경우_테스트() {
+    when(pointRepository.findByMemberIdForUpdate(1L)).thenReturn(Optional.empty());
+
+    CustomException customException = assertThrows(CustomException.class,
+        () -> pointService.usePoint(1L, BigDecimal.valueOf(100)));
+
+    Assertions.assertEquals(ErrorCode.NOT_FOUND_MEMBER, customException.getErrorCode());
+  }
+
+  @Test
   @DisplayName("포인트 사용시, 잔고가 적은 경우 IllegalStateException")
   public void 포인트_사용_잔고_부족_테스트() {
     Long memberId = point.getMemberId();
@@ -60,7 +73,10 @@ class PointServiceTest {
 
     when(pointRepository.findByMemberIdForUpdate(memberId)).thenReturn(Optional.of(point));
 
-    assertThrows(IllegalStateException.class, () -> pointService.usePoint(memberId, amountToUse));
+    CustomException customException = assertThrows(CustomException.class,
+        () -> pointService.usePoint(memberId, amountToUse));
+
+    Assertions.assertEquals(ErrorCode.NOT_ENOUGH_BALANCE, customException.getErrorCode());
   }
 
   @Test
@@ -93,6 +109,17 @@ class PointServiceTest {
   }
 
   @Test
+  @DisplayName("포인트 충전시, 멤버 없는 경우 NOT_FOUND_MEMBER Exception")
+  public void 포인트_충전_멤버_없는_경우_테스트() {
+    when(pointRepository.findByMemberIdForUpdate(1L)).thenReturn(Optional.empty());
+
+    CustomException customException = assertThrows(CustomException.class,
+        () -> pointService.chargePoint(1L, BigDecimal.valueOf(100)));
+
+    Assertions.assertEquals(ErrorCode.NOT_FOUND_MEMBER, customException.getErrorCode());
+  }
+
+  @Test
   @DisplayName("포인트 충전시, 충전 포인트가 음수인 경우 IllegalArgumentException")
   public void 포인트_충전_음수_테스트() {
     Long memberId = point.getMemberId();
@@ -108,6 +135,9 @@ class PointServiceTest {
   public void 포인트_조회시_멤버_ID가_없는_경우_익셉션() {
     when(pointRepository.findByMemberId(any(Long.class))).thenReturn(Optional.empty());
 
-    assertThrows(NoSuchElementException.class, () -> pointService.getPointByMemberId(1L));
+    CustomException customException = assertThrows(CustomException.class,
+        () -> pointService.getPointByMemberId(1L));
+
+    Assertions.assertEquals(ErrorCode.NOT_FOUND_MEMBER, customException.getErrorCode());
   }
 }

--- a/src/test/java/study/shinseungyeol/backend/domain/point/PointTest.java
+++ b/src/test/java/study/shinseungyeol/backend/domain/point/PointTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import study.shinseungyeol.backend.domain.member.Member;
+import study.shinseungyeol.backend.exception.CustomException;
+import study.shinseungyeol.backend.exception.ErrorCode;
 
 class PointTest {
 
@@ -67,7 +69,9 @@ class PointTest {
     BigDecimal balance = point.getBalanceAmount();
     BigDecimal balanceToUse = balance.add(BigDecimal.valueOf(1));
 
-    Assertions.assertThrows(IllegalStateException.class,
+    CustomException customException = Assertions.assertThrows(CustomException.class,
         () -> point.usePoint(balanceToUse));
+
+    Assertions.assertEquals(ErrorCode.NOT_ENOUGH_BALANCE, customException.getErrorCode());
   }
 }

--- a/src/test/java/study/shinseungyeol/backend/domain/reservation/ConcertSeatReservationServiceTest.java
+++ b/src/test/java/study/shinseungyeol/backend/domain/reservation/ConcertSeatReservationServiceTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.when;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,6 +15,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import study.shinseungyeol.backend.exception.CustomException;
+import study.shinseungyeol.backend.exception.ErrorCode;
 
 @ExtendWith(MockitoExtension.class)
 class ConcertSeatReservationServiceTest {
@@ -76,9 +77,11 @@ class ConcertSeatReservationServiceTest {
   public void 좌석_예약_완료_예약_없는_경우() {
     when(concertSeatReservationRepository.findByIdForUpdate(1L)).thenReturn(Optional.empty());
 
-    Assertions.assertThrows(NoSuchElementException.class, () -> {
+    CustomException customException = Assertions.assertThrows(CustomException.class, () -> {
       concertSeatReservationService.completeConcertSeatReservation(1L);
     });
+
+    Assertions.assertEquals(ErrorCode.NOT_FOUND_RESERVATION, customException.getErrorCode());
   }
 
   @Test

--- a/src/test/java/study/shinseungyeol/backend/domain/reservation/ConcertSeatReservationTest.java
+++ b/src/test/java/study/shinseungyeol/backend/domain/reservation/ConcertSeatReservationTest.java
@@ -3,6 +3,8 @@ package study.shinseungyeol.backend.domain.reservation;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import study.shinseungyeol.backend.exception.CustomException;
+import study.shinseungyeol.backend.exception.ErrorCode;
 
 class ConcertSeatReservationTest {
 
@@ -54,11 +56,15 @@ class ConcertSeatReservationTest {
   }
 
   @Test
-  public void 예약이_만료_되었는지_정상동작_테스트() {
+  public void 예약이_만료_되었는을_때_익셉션() {
     ConcertSeatReservation concertSeatReservation = new ConcertSeatReservation(1L, 1L, 1L,
         ReservationStatus.PENDING, LocalDateTime.now());
 
-    Assertions.assertTrue(concertSeatReservation.isExpired());
+    CustomException customException = Assertions.assertThrows(CustomException.class, () -> {
+      concertSeatReservation.checkIsExpired();
+    });
+
+    Assertions.assertEquals(ErrorCode.EXPIRED_SEAT_RESERVATION, customException.getErrorCode());
   }
 
   @Test
@@ -66,6 +72,6 @@ class ConcertSeatReservationTest {
     ConcertSeatReservation concertSeatReservation = new ConcertSeatReservation(1L, 1L, 1L,
         ReservationStatus.PENDING, LocalDateTime.now().plusSeconds(1));
 
-    Assertions.assertFalse(concertSeatReservation.isExpired());
+    concertSeatReservation.checkIsExpired();
   }
 }

--- a/src/test/java/study/shinseungyeol/backend/domain/token/TokenServiceTest.java
+++ b/src/test/java/study/shinseungyeol/backend/domain/token/TokenServiceTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
@@ -17,6 +16,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import study.shinseungyeol.backend.exception.CustomException;
+import study.shinseungyeol.backend.exception.ErrorCode;
 
 @ExtendWith(MockitoExtension.class)
 class TokenServiceTest {
@@ -58,8 +59,22 @@ class TokenServiceTest {
     UUID uuid = java.util.UUID.randomUUID();
     when(tokenRepository.findByIdForUpdate(uuid)).thenReturn(Optional.empty());
 
-    Assertions.assertThrows(NoSuchElementException.class,
+    CustomException customException = Assertions.assertThrows(CustomException.class,
+        () -> tokenService.getToken(uuid));
+
+    Assertions.assertEquals(ErrorCode.NOT_FOUND_TOKEN, customException.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("getTokenWithValidateActive 호출 시에 토큰이 없다면 에러가 나야 한다.")
+  public void 토큰_없는_경우_getTokenWithValidateActive() {
+    UUID uuid = java.util.UUID.randomUUID();
+    when(tokenRepository.findByIdForUpdate(uuid)).thenReturn(Optional.empty());
+
+    CustomException customException = Assertions.assertThrows(CustomException.class,
         () -> tokenService.getTokenWithValidateActive(uuid));
+
+    Assertions.assertEquals(ErrorCode.NOT_FOUND_TOKEN, customException.getErrorCode());
   }
 
   @Test

--- a/src/test/java/study/shinseungyeol/backend/usecase/point/PointUseCaseTest.java
+++ b/src/test/java/study/shinseungyeol/backend/usecase/point/PointUseCaseTest.java
@@ -4,7 +4,6 @@ import jakarta.transaction.Transactional;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,6 +26,8 @@ import study.shinseungyeol.backend.domain.reservation.ReservationStatus;
 import study.shinseungyeol.backend.domain.token.Token;
 import study.shinseungyeol.backend.domain.token.TokenRepository;
 import study.shinseungyeol.backend.domain.token.TokenStatus;
+import study.shinseungyeol.backend.exception.CustomException;
+import study.shinseungyeol.backend.exception.ErrorCode;
 import study.shinseungyeol.backend.infra.member.MemberRepository;
 import study.shinseungyeol.backend.usecase.point.dto.ChargePoint;
 import study.shinseungyeol.backend.usecase.point.dto.UsePoint.Command;
@@ -105,8 +106,10 @@ class PointUseCaseTest {
 
     Command command = new Command(activeToken.getId(), 300L);
 
-    Assertions.assertThrows(NoSuchElementException.class,
+    CustomException customException = Assertions.assertThrows(CustomException.class,
         () -> pointUseCase.usePointWithValidateToken(command));
+
+    Assertions.assertEquals(ErrorCode.NOT_FOUND_RESERVATION, customException.getErrorCode());
   }
 
   @Test


### PR DESCRIPTION
### 5주차 Default 과제 적용 

**로그는 step 09에 진행하였습니다**

**과제 내용** 
- 비즈니스 별 발생할 수 있는 에러 코드 정의 및 관리 체계 구축
- 프레임워크별 글로벌 에러 핸들러를 통해 예외 로깅 및 응답 처리 핸들러 구현

**구현 방법**
- 에러코드 Enum 클래스를 생성하여 관리체계 구축 
- spring ResponseEntityExceptionHandler 을 이용하여 익셉션 핸들러 구현 

**궁금한 점**
- 커스텀 익셉션이 어떤 레이어에 속한다고 볼 수 있을까요? - 커스텀 익셉션이 런타임 익셉션이기 때문에 전체 호출 스택으로 전파될 텐데 이걸 어떤 레이어에 속한다고 볼 수 있을 지가 궁금했습니다! 그래서 커스텀 익셉션과 강결합 되어있는 에러 코드에 **HTTP에 종속적인 HttpStatus 를 넣어도 되겠다는 판단을 했습니다!**

- request Dto를 @Vaild를 이용하지 않고 서비스 계층에서 파라미터를 검증하는 이유가 있을까요? @Vaild를 이용하면 컨트롤러 함수와 기타 다른 서비스함수까지 호출을 하지 않을 수 있어서 콜 스택을 낭비하지 않을 수 있는 장점이 있을 거 같았습니다! (스웨거 UI 문서에도 @NotEmpty를 붙일 경우 required 로 적용되는 것으로 알고있습니다) 제가 혹시라 놓친 부분이 있을까봐 여쭤봅니다! 